### PR TITLE
#96 Support for OCL export ZIP file.

### DIFF
--- a/api/src/main/java/org/openmrs/module/initializer/api/loaders/OpenConceptLabLoader.java
+++ b/api/src/main/java/org/openmrs/module/initializer/api/loaders/OpenConceptLabLoader.java
@@ -35,7 +35,6 @@ public class OpenConceptLabLoader extends BaseFileLoader {
 	protected void load(File file) throws Exception {
 		ZipFile zip = new ZipFile(file);
 		getImporter().run(zip);
-		
 	}
 	
 }

--- a/api/src/test/java/org/openmrs/module/initializer/api/OpenConceptLabLoaderIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/initializer/api/OpenConceptLabLoaderIntegrationTest.java
@@ -10,38 +10,56 @@
 package org.openmrs.module.initializer.api;
 
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openmrs.api.context.Context;
+import org.openmrs.module.DaemonToken;
+import org.openmrs.module.ModuleFactory;
 import org.openmrs.module.initializer.DomainBaseModuleContextSensitiveTest;
 import org.openmrs.module.initializer.api.loaders.OpenConceptLabLoader;
+import org.openmrs.module.openconceptlab.OpenConceptLabActivator;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.openmrs.module.openconceptlab.Utils;
-import java.util.zip.ZipFile;
-import java.io.IOException;
-import java.io.InputStream;
+
+import java.lang.reflect.Field;
+import java.util.Map;
 import org.openmrs.Concept;
 
 public class OpenConceptLabLoaderIntegrationTest extends DomainBaseModuleContextSensitiveTest {
 	
 	@Autowired
 	private OpenConceptLabLoader loader;
+
+	@SuppressWarnings("unchecked")
+	@BeforeClass
+	public static void setupDaemonToken() {
+		Map<String, DaemonToken> daemonTokens;
+		try {
+			Field field = ModuleFactory.class.getDeclaredField("daemonTokens");
+			field.setAccessible(true);
+			daemonTokens = (Map<String, DaemonToken>) field.get(null);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		DaemonToken daemonToken = new DaemonToken("openconceptlab");
+		daemonTokens.put(daemonToken.getId(), daemonToken);
+		new OpenConceptLabActivator().setDaemonToken(daemonToken);
+	}
 	
 	@Test
-	public void load_shouldImportOCLPackages() throws IOException {
-		
-		Utils utils = null;
-		ZipFile zipFile = new ZipFile(
-		        "src/test/resources/testAppDataDir/configuration/openconceptlab/CIEL_v2021-01-29.20210204075515.zip");
-		InputStream is = utils.extractExportInputStreamFromZip(zipFile);
-		
+	public void load_shouldImportOCLPackages() {
+		{
+			Concept c = Context.getConceptService().getConceptByUuid("4421da0d-42d0-410d-8ffd-47ec6f155d8f");
+			Assert.assertNull(c);
+		}
+
 		loader.load();
 		
 		{
-		Concept c = null;
-		c = Context.getConceptService().getConceptByUuid("4421da0d-42d0-410d-8ffd-47ec6f155d8f");
-		Assert.assertEquals(2, c.getSetMembers().size());
-		Assert.assertTrue(c.isSet());
+			Concept c  = Context.getConceptService().getConceptByUuid("4421da0d-42d0-410d-8ffd-47ec6f155d8f");
+			Assert.assertEquals(2, c.getSetMembers().size());
+			Assert.assertTrue(c.getSet());
 		}
-		
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,6 @@
             <version>1.6.1</version>
             <scope>test</scope>
         </dependency>
- 		<dependency>
-   			<groupId>org.springframework</groupId>
-    		<artifactId>spring-web</artifactId>
-    		<version>5.0.3.RELEASE</version>
-		</dependency>
         <dependency>
             <groupId>org.openmrs.api</groupId>
             <artifactId>openmrs-api</artifactId>


### PR DESCRIPTION
Hi Suruchi!

This is a PR to fix the test (a bit) for me. I tried running things locally and I don't seem to need the Spring framework bit, but I did need to add some setup code (stolen from the OpenConceptLab module). The annoying thing is that this reveals a bug in the OpenConceptLab module where [it requires a subscription to be able to save any concept](https://github.com/openmrs/openmrs-module-openconceptlab/blob/73e758240b2f6c241460514ebb871e4219bc88c6/api/src/main/java/org/openmrs/module/openconceptlab/importer/Saver.java#L120), which obviously fails for this use case.

I think we need to update the OpenConceptLab module to do something like this:

```java
ValidationType validationType;

if (importService.getSubscription() != null) {
	importService.getSubscription().getValidationType();
} else {
	validationType = ValidationType.FULL;
}
```
